### PR TITLE
feat: Add state practice mode, image display, and UI updates

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -7,12 +7,14 @@ import FlashcardMode from "./feature/flashcard/FlashcardMode";
 import HomePage from "./component/HomePage";
 import SettingsPage from "./component/SettingsPage";
 import BummerPage from "./component/BummerPage";
+import StatePracticeMode from "./feature/state-practice/StatePracticeMode"; // Add this
 import { Question, StatesData, ExamResultsData, Language } from "./types";
 
 interface AppRoutesProps {
   onStartPractice: (stateCode: string) => void;
   onStartExam: (stateCode: string) => void;
   onStartFlashcards: (stateCode: string) => void;
+  onStartStatePractice: (stateCode: string) => void; // New prop
 
   statesData: StatesData;
   selectedState: string;
@@ -23,6 +25,7 @@ interface AppRoutesProps {
   availableLanguages: Language[];
 
   practiceSessionQuestions: Question[];
+  statePracticeSessionQuestions: Question[]; // New prop
 
   examQuestionsForMode: Question[];
   onShowResultsPage: (results: ExamResultsData) => void;
@@ -40,6 +43,7 @@ const AppRoutes: React.FC<AppRoutesProps> = ({
   onStartPractice,
   onStartExam,
   onStartFlashcards,
+  onStartStatePractice, // New prop
   statesData,
   selectedState,
   onStateChange,
@@ -48,6 +52,7 @@ const AppRoutes: React.FC<AppRoutesProps> = ({
   onLanguageChange,
   availableLanguages,
   practiceSessionQuestions,
+  statePracticeSessionQuestions, // New prop
   examQuestionsForMode,
   onShowResultsPage,
   examResultsData,
@@ -65,11 +70,37 @@ const AppRoutes: React.FC<AppRoutesProps> = ({
             onStartPractice={onStartPractice}
             onStartExam={onStartExam}
             onStartFlashcards={onStartFlashcards}
+            onStartStatePractice={onStartStatePractice} // Pass it here
             selectedState={selectedState}
+            statesData={statesData} // Pass statesData
           />
         }
       />
       <Route path="/" element={<Navigate to="/home" replace />} />
+      <Route
+        path="/state-practice"
+        element={
+          // Replace with actual StatePracticeMode component once created
+          // For now, to make this file syntactically valid if StatePracticeMode is not yet defined,
+          // we might put a placeholder or ensure the component is created in the next step.
+          // Assuming StatePracticeMode will be similar to PracticeMode:
+          /*
+          <StatePracticeMode
+            questions={statePracticeSessionQuestions}
+            onNavigateHome={onNavigateHome}
+            selectedLanguageCode={selectedLanguage}
+          />
+          */
+          // To prevent errors in this subtask as StatePracticeMode.tsx doesn't exist yet,
+          // I will use PracticeMode as a placeholder, but this will be changed in the next step.
+          // This is a temporary measure to ensure the subtask can complete.
+          <StatePracticeMode // Update this
+            questions={statePracticeSessionQuestions}
+            onNavigateHome={onNavigateHome}
+            selectedLanguageCode={selectedLanguage}
+          />
+        }
+      />
       <Route
         path="/practice"
         element={

--- a/src/component/HomePage.tsx
+++ b/src/component/HomePage.tsx
@@ -1,18 +1,23 @@
 import React from "react";
 import { logAnalyticsEvent } from "../analytics/analytics";
+import { StatesData } from "../types"; // Add this
 
 interface HomePageProps {
   onStartPractice: (stateCode: string) => void;
   onStartExam: (stateCode: string) => void;
   onStartFlashcards: (stateCode: string) => void;
+  onStartStatePractice: (stateCode: string) => void; // New
   selectedState: string;
+  statesData: StatesData; // New
 }
 
 const HomePage: React.FC<HomePageProps> = ({
   onStartPractice,
   onStartExam,
   onStartFlashcards,
+  onStartStatePractice, // New
   selectedState,
+  statesData, // New
 }) => {
   const handleActivityNavigation = (
     activityStartFunction: (stateCode: string) => void
@@ -26,7 +31,40 @@ const HomePage: React.FC<HomePageProps> = ({
     activityStartFunction(selectedState);
   };
 
+  const stateName = selectedState && statesData[selectedState] ? statesData[selectedState] : "";
+  const dynamicTitle = stateName ? `Practice for ${stateName}` : "State Practice";
+  const dynamicSubtitle = stateName ? `10 quick questions for ${stateName}.` : "Select a state in settings first.";
+
   const cardData = [
+    {
+      id: "state-practice",
+      title: dynamicTitle,
+      subtitle: dynamicSubtitle,
+      icon: ( // Reusing practice icon, consider a new one later
+        <svg
+          className="w-12 h-12 mb-4 text-indigo-500" // Changed color slightly
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          {/* Using a map or location pin icon might be more thematic */}
+          <path d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
+          <path d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
+        </svg>
+      ),
+      action: () => {
+        logAnalyticsEvent("select_content", {
+          content_type: "button",
+          item_id: "start_state_practice",
+          selected_state: selectedState, // This will be empty if no state selected, which is fine
+        });
+        // handleActivityNavigation already checks for selectedState
+        handleActivityNavigation(onStartStatePractice);
+      },
+    },
     {
       id: "practice",
       title: "Practice Questions",

--- a/src/feature/exam/QuestionDisplay.tsx
+++ b/src/feature/exam/QuestionDisplay.tsx
@@ -53,6 +53,17 @@ const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
       <h3 className="text-lg md:text-xl font-medium mb-1">
         {currentQuestion.question_text}
       </h3>
+      {/* START: Added image display */}
+      {currentQuestion.image && (
+        <div className="my-4 text-center">
+          <img
+            src={currentQuestion.image}
+            alt={`Illustration for question ${currentQuestion.id}`}
+            className="max-w-full h-auto rounded-md shadow-sm inline-block"
+          />
+        </div>
+      )}
+      {/* END: Added image display */}
       {!isExamMode && currentQuestion.question_text_translation && (
         <p className="text-sm text-gray-500 mt-1 mb-4 italic">
           {`(${getLanguageName(selectedLanguageCode)}) ${currentQuestion.question_text_translation}`}

--- a/src/feature/flashcard/FlashcardMode.tsx
+++ b/src/feature/flashcard/FlashcardMode.tsx
@@ -220,6 +220,17 @@ const FlashcardMode: React.FC<FlashcardModeProps> = ({
       </div>
 
       <div className="bg-gray-50 p-6 rounded-lg shadow-inner min-h-[150px] flex flex-col justify-center items-center mb-6">
+        {/* START: Added image display */}
+        {currentCard.image && (
+          <div className="mb-3 text-center"> {/* text-center for centering */}
+            <img
+              src={currentCard.image}
+              alt={`Illustration for question ${currentCard.id}`}
+              className="max-w-xs h-auto rounded-md shadow-sm inline-block" // max-w-xs to constrain size a bit on flashcards
+            />
+          </div>
+        )}
+        {/* END: Added image display */}
         <h3 className="text-xl md:text-2xl font-semibold text-gray-800 mb-2">
           {currentCard.question_text}
         </h3>

--- a/src/feature/practice/PracticeMode.tsx
+++ b/src/feature/practice/PracticeMode.tsx
@@ -227,6 +227,17 @@ const PracticeMode: React.FC<PracticeModeProps> = ({
               {`${currentQuestion.question_text_translation}`}
             </p>
           )}
+          {/* START: Added image display */}
+          {currentQuestion.image && (
+            <div className="my-4 text-center"> {/* Added text-center to center the image if it's smaller than container */}
+              <img
+                src={currentQuestion.image}
+                alt={`Illustration for question ${currentQuestion.id}`}
+                className="max-w-full h-auto rounded-md shadow-sm inline-block" // inline-block for text-center to take effect
+              />
+            </div>
+          )}
+          {/* END: Added image display */}
           <div className="space-y-3">
             {currentQuestion.options.map((opt: Option) => {
               let btnClass = "border-gray-300 hover:bg-gray-100 text-gray-800";

--- a/src/feature/state-practice/StatePracticeMode.tsx
+++ b/src/feature/state-practice/StatePracticeMode.tsx
@@ -1,0 +1,159 @@
+// src/feature/state-practice/StatePracticeMode.tsx
+import React, { useState, useEffect } from "react";
+import { Question, Option } from "../../types"; // Ensure this path is correct
+// import { logAnalyticsEvent } from "../../analytics/analytics"; // If adding analytics
+
+interface StatePracticeModeProps {
+  questions: Question[];
+  onNavigateHome: () => void;
+  selectedLanguageCode: string;
+}
+
+// Minimal UserAnswer type for this mode
+interface UserAnswer {
+  answer: string | null;
+  correct: boolean | null;
+}
+interface UserAnswers {
+  [questionId: string]: UserAnswer;
+}
+
+const StatePracticeMode: React.FC<StatePracticeModeProps> = ({
+  questions,
+  onNavigateHome,
+  selectedLanguageCode,
+}) => {
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState<number>(0);
+  const [userAnswers, setUserAnswers] = useState<UserAnswers>({});
+
+  // Reset state if questions prop changes (e.g., user goes home and starts a new session for a different state)
+  useEffect(() => {
+    setCurrentQuestionIndex(0);
+    setUserAnswers({});
+  }, [questions]);
+
+  if (!questions || questions.length === 0) {
+    return (
+      <div className="text-center p-4">
+        <p className="text-xl text-gray-700 mb-4">
+          No specific practice questions available for this state, or an error occurred.
+        </p>
+      </div>
+    );
+  }
+
+  const currentQuestion = questions[currentQuestionIndex];
+  const userAnswerInfo = userAnswers[currentQuestion.id];
+  const isAnswered = userAnswerInfo?.answer !== null && userAnswerInfo?.answer !== undefined;
+
+  const handleAnswerSelection = (questionId: string, selectedOptionId: string) => {
+    if (userAnswers[questionId]?.answer) return; // Already answered
+    const question = questions.find((q) => q.id === questionId);
+    if (!question) return;
+    const isCorrect = selectedOptionId === question.correct_answer;
+    setUserAnswers((prev) => ({
+      ...prev,
+      [questionId]: { answer: selectedOptionId, correct: isCorrect },
+    }));
+  };
+
+  const handleNavigate = (direction: number) => {
+    const newIndex = currentQuestionIndex + direction;
+    if (newIndex >= 0 && newIndex < questions.length) {
+      setCurrentQuestionIndex(newIndex);
+    }
+    // No automatic navigation to results or home. User uses main navigation or provided home button.
+  };
+
+  // Basic JSX structure (adapt from PracticeMode.tsx, simplifying as needed)
+  return (
+    <div className="bg-white p-4 md:p-6 rounded-lg shadow-lg max-w-3xl mx-auto">
+      <p className="text-sm text-gray-600 mb-3">
+        State Practice: Question {currentQuestionIndex + 1} of {questions.length}
+      </p>
+      <h3 className="text-lg md:text-xl font-semibold mb-1">
+        {currentQuestion.question_text}
+      </h3>
+      {currentQuestion.question_text_translation && (
+        <p className="text-sm text-gray-500 mt-1 mb-4 italic">
+          {currentQuestion.question_text_translation}
+        </p>
+      )}
+      {/* START: Added image display */}
+      {currentQuestion.image && (
+        <div className="my-4 text-center">
+          <img
+            src={currentQuestion.image}
+            alt={`Illustration for question ${currentQuestion.id}`}
+            className="max-w-full h-auto rounded-md shadow-sm inline-block"
+          />
+        </div>
+      )}
+      {/* END: Added image display */}
+      <div className="space-y-3">
+        {currentQuestion.options.map((opt: Option) => {
+          let btnClass = "border-gray-300 hover:bg-gray-100 text-gray-800";
+          if (isAnswered && userAnswerInfo) {
+            if (opt.id === userAnswerInfo.answer) {
+              btnClass = userAnswerInfo.correct
+                ? "bg-green-200 border-green-400 text-green-800 pointer-events-none"
+                : "bg-red-200 border-red-400 text-red-800 pointer-events-none";
+            } else if (opt.id === currentQuestion.correct_answer) {
+              btnClass = "bg-green-100 border-green-300 text-green-700 pointer-events-none opacity-90";
+            } else {
+              btnClass = "border-gray-200 text-gray-500 pointer-events-none opacity-70";
+            }
+          }
+          return (
+            <button
+              key={opt.id}
+              onClick={() => handleAnswerSelection(currentQuestion.id, opt.id)}
+              disabled={isAnswered}
+              className={`option-btn block w-full text-left p-3 border rounded-md transition-all ${btnClass}`}
+            >
+              <div>
+                <span className="font-bold mr-2">{opt.id.toUpperCase()}.</span> {opt.text}
+              </div>
+              {opt.text_translation && (
+                <div className="italic text-xs text-gray-500 ml-6 mt-1">
+                  {opt.text_translation}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      {isAnswered && userAnswerInfo && (
+        <div
+          className={`mt-4 p-3 rounded-md ${userAnswerInfo.correct ? "bg-green-50 text-green-700 border border-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}
+        >
+          {userAnswerInfo.correct ? "Correct!" : "Incorrect."}
+          {!userAnswerInfo.correct && (
+            <span> Correct answer: <span className="font-bold">{currentQuestion.correct_answer.toUpperCase()}</span>.</span>
+          )}
+          {currentQuestion.explanation && (
+            <p className="text-sm mt-1">{currentQuestion.explanation}</p>
+          )}
+        </div>
+      )}
+      <div className="mt-6 flex justify-between items-center mb-2">
+        <button
+          onClick={() => handleNavigate(-1)}
+          disabled={currentQuestionIndex === 0}
+          className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <button
+          onClick={() => handleNavigate(1)}
+          disabled={currentQuestionIndex === questions.length - 1 || !isAnswered}
+          className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StatePracticeMode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface Question {
   correct_answer: string;
   explanation?: string;
   state_code: string | null;
+  image?: string; // Add this line
 
   num?: string;
   translation?: {
@@ -58,6 +59,7 @@ export interface RawQuestion {
   id: string;
   num?: string;
   question?: string;
+  image?: string; // Add this line
   a?: string;
   b?: string;
   c?: string;


### PR DESCRIPTION
This commit introduces several key features and improvements:

1.  **State-Specific Practice Mode:**
    *   Added a new card to the HomePage that dynamically updates its title based on the selected state (e.g., "Practice for Berlin").
    *   Clicking this card navigates to a new `/state-practice` route.
    *   `StatePracticeMode.tsx` displays 10 questions specific to the selected state.
    *   The "Back to Home" button was initially added and then removed from `StatePracticeMode.tsx` as per your feedback, relying on header navigation.

2.  **Image Display in Questions:**
    *   Updated `src/types.ts` to include an optional `image` property in `Question` and `RawQuestion` types.
    *   Modified `src/App.tsx` to process the `image` field from raw data. If `image` is "-", it's treated as no image; otherwise, the URL is used.
    *   Enhanced all quiz modes to display images if an image URL is present for a question:
        *   `src/feature/practice/PracticeMode.tsx`
        *   `src/feature/exam/QuestionDisplay.tsx` (used by ExamMode)
        *   `src/feature/flashcard/FlashcardMode.tsx`
        *   `src/feature/state-practice/StatePracticeMode.tsx`
    *   Images are displayed with responsive styling.

3.  **Core Logic Updates:**
    *   `App.tsx` handles the state and logic for fetching/filtering questions for the new state practice mode.
    *   `AppRoutes.tsx` includes the new route and prop drilling.
    *   Analytics event added for starting state-specific practice.